### PR TITLE
Do not depend on insecure module Email::Address

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,8 +21,8 @@ my %WriteMakefileArgs = (
   "MIN_PERL_VERSION" => "5.010000",
   "NAME" => "App::Github::Email",
   "PREREQ_PM" => {
-    "Email::Address" => 0,
     "Getopt::Long::Descriptive" => 0,
+    "JSON" => 0,
     "LWP::Online" => 0,
     "LWP::UserAgent" => 0,
     "List::MoreUtils" => 0,
@@ -40,8 +40,8 @@ my %WriteMakefileArgs = (
 
 
 my %FallbackPrereqs = (
-  "Email::Address" => 0,
   "Getopt::Long::Descriptive" => 0,
+  "JSON" => 0,
   "LWP::Online" => 0,
   "LWP::UserAgent" => 0,
   "List::MoreUtils" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
-requires "Email::Address" => "0";
 requires "Getopt::Long::Descriptive" => "0";
+requires "JSON" => "0";
 requires "LWP::Online" => "0";
 requires "LWP::UserAgent" => "0";
 requires "List::MoreUtils" => "0";

--- a/lib/App/Github/Email.pm
+++ b/lib/App/Github/Email.pm
@@ -6,8 +6,8 @@ use strict;
 use warnings;
 use v5.10;
 
+use JSON;
 use LWP::UserAgent;
-use Email::Address;
 use List::MoreUtils qw(uniq);
 
 =head2 Functions
@@ -35,7 +35,10 @@ sub get_user {
 
     if ( $get_json->is_success ) {
         my $raw_json    = $get_json->decoded_content;
-        my @addresses   = Email::Address->parse($raw_json);
+        my $dec_json    = decode_json $raw_json;
+        my @push_events = grep { $_->{type} eq 'PushEvent' } @{$dec_json};
+        my @commits     = map { @{$_->{payload}->{commits}} } @push_events;
+        my @addresses   = map { $_->{author}->{email} } @commits;
         my @unique_addr = uniq @addresses;
         my @retrieved_addrs;
 

--- a/t/Email.t
+++ b/t/Email.t
@@ -2,7 +2,7 @@ use Test::More tests => 7;
 
 use_ok('LWP::UserAgent');
 use_ok('Getopt::Long::Descriptive');
-use_ok('Email::Address');
+use_ok('JSON');
 use_ok( 'List::MoreUtils', qw(uniq) );
 use_ok( 'LWP::Online',     qw(online) );
 use_ok('App::Github::Email');


### PR DESCRIPTION
Method Email::Address->parse is vulnerable to CVE-2015-7686 and also does
not parse list of email addresses correctly. This patch replace searching
for email addresses by proper JSON API decoding.